### PR TITLE
build: add vscode debug launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "extensionHost",
+      "request": "launch",
+      "name": "Launch Client",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "outFiles": ["${workspaceRoot}/src/index.js"]
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Server",
+      "port": 6009,
+      "restart": true,
+      "outFiles": ["${workspaceRoot}/src/server.js"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Client + Server",
+      "configurations": ["Launch Client", "Attach to Server"]
+    }
+  ]
+}


### PR DESCRIPTION
based off https://github.com/microsoft/vscode-extension-samples/blob/master/lsp-sample/.vscode/launch.json

Allows launching client and server in debug mode from inside vscode.

![vscode-debug-launch](https://user-images.githubusercontent.com/3107513/65380606-b36bcb00-dc93-11e9-8650-d1db5047ab5b.gif)

