### PR TITLE
Add support for VS Code Quick Fixes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,8 @@ import {engine} from 'unified-engine'
 import {VFile} from 'vfile'
 import {
   createConnection,
+  CodeAction,
+  CodeActionKind,
   Diagnostic,
   DiagnosticSeverity,
   Position,
@@ -100,6 +102,12 @@ function vfileMessageToDiagnostic(message) {
   )
   if (message.url) {
     diagnostic.codeDescription = {href: message.url}
+  }
+
+  if (message.expected) {
+    diagnostic.data = {
+      expected: message.expected
+    }
   }
 
   return diagnostic
@@ -199,7 +207,11 @@ export function configureUnifiedLanguageServer(
   connection.onInitialize(() => ({
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Full,
-      documentFormattingProvider: true
+      documentFormattingProvider: true,
+      codeActionProvider: {
+        codeActionKinds: [CodeActionKind.QuickFix],
+        resolveProvider: true
+      }
     }
   }))
 
@@ -237,6 +249,59 @@ export function configureUnifiedLanguageServer(
 
   connection.onDidChangeWatchedFiles(() => {
     checkDocuments(...documents.all())
+  })
+
+  connection.onCodeAction((event) => {
+    /** @type {CodeAction[]} */
+    const codeActions = []
+
+    const document = documents.get(event.textDocument.uri)
+    if (!document) {
+      return
+    }
+
+    const text = document.getText()
+
+    for (const diagnostic of event.context.diagnostics) {
+      const {data} = diagnostic
+      if (typeof data !== 'object' || !data) {
+        continue
+      }
+
+      const {expected} = /** @type {{expected?: string[]}} */ (data)
+
+      if (!Array.isArray(expected)) {
+        continue
+      }
+
+      const {end, start} = diagnostic.range
+      const actual = text.slice(
+        document.offsetAt(start),
+        document.offsetAt(end)
+      )
+
+      for (const replacement of expected) {
+        codeActions.push(
+          CodeAction.create(
+            replacement
+              ? start.line === end.line && start.character === end.character
+                ? 'Insert `' + replacement + '`'
+                : 'Replace `' + actual + '` with `' + replacement + '`'
+              : 'Remove `' + actual + '`',
+            {
+              changes: {
+                [document.uri]: [
+                  TextEdit.replace(diagnostic.range, replacement)
+                ]
+              }
+            },
+            CodeActionKind.QuickFix
+          )
+        )
+      }
+    }
+
+    return codeActions
   })
 }
 

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,11 @@ options.
 Language servers created using this package implement the following language
 server features:
 
+*   `textDocument/codeAction`
+    — The language server implements code actions based on the `expected` field
+    on reported messages.
+    A code action can either insert, replace, or delete text based on the range
+    of the message and the expected value.
 *   `textDocument/didChange`
     — when a document is changed by the client, the language server processes it
     using a unified pipeline.

--- a/test/test-plugin.js
+++ b/test/test-plugin.js
@@ -56,6 +56,11 @@ export default function unifiedTestPlugin() {
       message.url = 'https://example.com'
     }
 
+    if (value.includes('expected')) {
+      const message = file.message('expected')
+      message.expected = ['suggestion']
+    }
+
     if (value.includes('has error')) {
       throw new Error('Test error')
     }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This implements manual quick fixes (**not to be confused with auto fixes!**) by replacing the reported range with values taken from the `expected` array on vfile messages.

<!--do not edit: pr-->
