### PR TITLE
Add tests for previously undefined behavior on errors

### DIFF
--- a/test/test-plugin.js
+++ b/test/test-plugin.js
@@ -1,11 +1,24 @@
 /**
- * @type import('unified').Plugin
+ * @typedef {object} UnifiedTestPluginOptions
+ * @property {'plugin' | 'transformer'} [error]
  */
-export default function unifiedTestPlugin() {
+
+/**
+ * @type import('unified').Plugin<[UnifiedTestPluginOptions]>
+ */
+export default function unifiedTestPlugin({error} = {}) {
   this.Parser = () => ({type: 'root'})
   this.Compiler = () => 'Formatted output\n'
 
+  if (error === 'plugin') {
+    throw new Error('Plugin error')
+  }
+
   return (ast, file) => {
+    if (error === 'transformer') {
+      throw new Error('Transformer error')
+    }
+
     const value = String(file)
     if (value.includes('no position')) {
       file.message('no position')


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This is really handled by unified-engine, but it’s nice to assert how the language server handles these situations.


<!--do not edit: pr-->
