### PR TITLE
Add support for passing a processor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,15 @@
  * @typedef {import('unist').Position} UnistPosition
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('vscode-languageserver').Connection} Connection
- * @typedef {Pick<
+ * @typedef {Partial<Pick<
  *   import('unified-engine').Options,
- *   'ignoreName' | 'packageField' | 'pluginPrefix' | 'plugins' | 'rcName'
- * >} Options
+ *   | 'ignoreName'
+ *   | 'packageField'
+ *   | 'pluginPrefix'
+ *   | 'plugins'
+ *   | 'processor'
+ *   | 'rcName'
+ * >>} Options
  */
 
 import {PassThrough} from 'node:stream'
@@ -136,7 +141,14 @@ function lspDocumentToVfile(document) {
 export function configureUnifiedLanguageServer(
   connection,
   documents,
-  {ignoreName, packageField, pluginPrefix, plugins, rcName}
+  {
+    ignoreName,
+    packageField,
+    pluginPrefix,
+    plugins,
+    processor = unified(),
+    rcName
+  }
 ) {
   /**
    * Process various LSP text documents using unified and send back the
@@ -156,7 +168,7 @@ export function configureUnifiedLanguageServer(
           packageField,
           pluginPrefix,
           plugins,
-          processor: unified(),
+          processor,
           quiet: false,
           rcName,
           silentlyIgnore: true,

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,8 @@ Create a file names `package.json` with the following content:
   "bin": "./index.js",
   "type": "module",
   "dependencies": {
-    "unified-language-server"
+    "remark": "^14.0.0",
+    "unified-language-server": "^1.0.0"
   }
 }
 ```
@@ -83,6 +84,7 @@ Create a file names `package.json` with the following content:
 Then create `index.js` with the following content:
 
 ```js
+import {remark} from 'remark'
 import {createUnifiedLanguageServer} from 'unified-language-server'
 
 process.title = 'remark-language-server'
@@ -91,7 +93,7 @@ createUnifiedLanguageServer({
   ignoreName: '.remarkignore',
   packageField: 'remarkConfig',
   pluginPrefix: 'remark',
-  plugins: ['remark-parse', 'remark-stringify'],
+  processor: remark,
   rcName: '.remarkrc'
 })
 ```


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This is mainly to handle the situation if plugins are not available in certain situations. I.e. if remark language server is started in a project where `remark-parse` or `remark-stringify` is not available.

<!--do not edit: pr-->
