### PR TITLE
Add support for loading local processors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,21 +3,39 @@
  * @typedef {import('unist').Position} UnistPosition
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('vscode-languageserver').Connection} Connection
- * @typedef {Partial<Pick<
- *   import('unified-engine').Options,
+ * @typedef {import('unified-engine').Options} EngineOptions
+ * @typedef {Pick<
+ *   EngineOptions,
  *   | 'ignoreName'
  *   | 'packageField'
  *   | 'pluginPrefix'
  *   | 'plugins'
- *   | 'processor'
  *   | 'rcName'
- * >>} Options
+ * >} EngineFields
+ *
+ * @typedef LanguageServerFields
+ * @property {string} processorName
+ *   The package ID of the expected processor (example: `'remark'`).
+ *   Will be loaded from the local workspace.
+ * @property {string} [processorSpecifier='default']
+ *   The specifier to get the processor on the resolved module.
+ *   For example, remark uses the specifier `remark` to expose its processor and
+ *   a default export can be requested by passing `'default'` (the default).
+ * @property {EngineOptions['processor']} [defaultProcessor]
+ *   Optional fallback processor to use if `processorName` can’t be found
+ *   locally in `node_modules`.
+ *   This can be used to ship a processor with your package, to be used if no
+ *   processor is found locally.
+ *   If this isn’t passed, a warning is shown if `processorName` can’t be found.
+ *
+ * @typedef {EngineFields & LanguageServerFields} Options
  */
 
 import {PassThrough} from 'node:stream'
+import process from 'node:process'
 import {URL, pathToFileURL} from 'node:url'
 
-import {unified} from 'unified'
+import {loadPlugin} from 'load-plugin'
 import {engine} from 'unified-engine'
 import {VFile} from 'vfile'
 import {
@@ -140,7 +158,9 @@ export function configureUnifiedLanguageServer(
     packageField,
     pluginPrefix,
     plugins,
-    processor = unified(),
+    processorName,
+    processorSpecifier = 'default',
+    defaultProcessor,
     rcName
   }
 ) {
@@ -152,7 +172,39 @@ export function configureUnifiedLanguageServer(
    * @param {boolean} alwaysStringify
    * @returns {Promise<VFile[]>}
    */
-  function processDocuments(textDocuments, alwaysStringify = false) {
+  async function processDocuments(textDocuments, alwaysStringify = false) {
+    /** @type {EngineOptions['processor']} */
+    let processor
+
+    try {
+      // @ts-expect-error: assume we load a unified processor.
+      processor = await loadPlugin(processorName, {
+        cwd: process.cwd(),
+        key: processorSpecifier
+      })
+    } catch (error) {
+      const exception = /** @type {NodeJS.ErrnoException} */ (error)
+
+      // Pass other funky errors through.
+      /* c8 ignore next 3 */
+      if (exception.code !== 'ERR_MODULE_NOT_FOUND') {
+        throw error
+      }
+
+      if (!defaultProcessor) {
+        connection.window.showInformationMessage(
+          'Cannot turn on language server without `' +
+            processorName +
+            '` locally. Run `npm install ' +
+            processorName +
+            '` to enable it'
+        )
+        return []
+      }
+
+      processor = defaultProcessor
+    }
+
     return new Promise((resolve, reject) => {
       engine(
         {

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,11 +240,12 @@ export function configureUnifiedLanguageServer(
           } else {
             resolve((context && context.files) || [])
           }
-          /* c8 ignore stop */
         }
       )
     })
   }
+
+  /* c8 ignore stop */
 
   /**
    * Process various LSP text documents using unified and send back the

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,6 +202,15 @@ export function configureUnifiedLanguageServer(
         return []
       }
 
+      const problem = new Error(
+        'Cannot find `' +
+          processorName +
+          '` locally but using `defaultProcessor`, original error:\n' +
+          exception.stack
+      )
+
+      connection.console.log(String(problem))
+
       processor = defaultProcessor
     }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@types/unist": "^2.0.0",
+    "load-plugin": "^4.0.0",
     "unified": "^10.0.0",
     "unified-engine": "^9.0.0",
     "vfile": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@types/unist": "^2.0.0",
     "load-plugin": "^4.0.0",
-    "unified": "^10.0.0",
     "unified-engine": "^9.0.0",
     "vfile": "^5.0.0",
     "vfile-message": "^3.0.0",
@@ -52,6 +51,7 @@
     "tape": "^5.0.0",
     "type-coverage": "^2.0.0",
     "typescript": "^4.0.0",
+    "unified": "^10.0.0",
     "xo": "^0.47.0"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -93,8 +93,10 @@ createUnifiedLanguageServer({
   ignoreName: '.remarkignore',
   packageField: 'remarkConfig',
   pluginPrefix: 'remark',
-  processor: remark,
-  rcName: '.remarkrc'
+  rcName: '.remarkrc',
+  processorName: 'remark',
+  processorSpecifier: 'remark',
+  defaultProcessor: remark
 })
 ```
 
@@ -111,28 +113,47 @@ Create a language server for a unified ecosystem.
 
 Configuration for `unified-engine` and the language server.
 
+###### `options.processorName`
+
+The package ID of the expected processor (`string`, required, example:
+`'remark'`).
+Will be loaded from the local workspace.
+
+###### `options.processorSpecifier`
+
+The specifier to get the processor on the resolved module (`string`, optional,
+default: `'default'`).
+For example, remark uses the specifier `remark` to expose its processor and
+a default export can be requested by passing `'default'` (the default).
+
+###### `options.defaultProcessor`
+
+Optional fallback processor to use if `processorName` can’t be found
+locally in `node_modules` ([`Unified`][unified], optional).
+This can be used to ship a processor with your package, to be used if no
+processor is found locally.
+If this isn’t passed, a warning is shown if `processorName` can’t be found.
+
 ###### `options.ignoreName`
 
-Name of ignore files to load (`string`, optional)
+Name of ignore files to load (`string`, optional).
 
 ###### `options.packageField`
 
 Property at which configuration can be found in package.json files (`string`,
-optional)
+optional).
 
 ###### `options.pluginPrefix`
 
-Optional prefix to use when searching for plugins (`string`, optional)
+Optional prefix to use when searching for plugins (`string`, optional).
 
 ###### `options.plugins`
 
-Plugins to use by default (`Array|Object`, optional)
-
-Typically this contains 2 plugins named `*-parse` and `*-stringify`.
+Plugins to use by default (`Array|Object`, optional).
 
 ###### `options.rcName`
 
-Name of configuration files to load (`string`, optional)
+Name of configuration files to load (`string`, optional).
 
 ## Examples
 

--- a/test/index.js
+++ b/test/index.js
@@ -327,13 +327,21 @@ test('uninstalled processor w/ `defaultProcessor`', async (t) => {
   } catch (error) {
     const exception = /** @type {ExecError} */ (error)
     const messages = fromMessages(exception.stdout)
-    t.equal(messages.length, 2, 'should emit messages')
+    t.equal(messages.length, 3, 'should emit messages')
+
     const parameters =
-      /** @type {import('vscode-languageserver').PublishDiagnosticsParams} */ (
+      /** @type {import('vscode-languageserver').LogMessageParams} */ (
         messages[1].params
       )
 
-    t.deepEqual(parameters.diagnostics, [], 'should work w/ `defaultProcessor`')
+    t.deepEqual(
+      cleanStack(parameters.message, 3).replace(
+        /(imported from )[^\r\n]+/,
+        '$1zzz'
+      ),
+      "Error: Cannot find `xxx-missing-yyy` locally but using `defaultProcessor`, original error:\nError [ERR_MODULE_NOT_FOUND]: Cannot find package 'xxx-missing-yyy' imported from zzz\n    at new NodeError (errors.js:1:1)",
+      'should work w/ `defaultProcessor`'
+    )
   }
 
   t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -335,11 +335,11 @@ test('uninstalled processor w/ `defaultProcessor`', async (t) => {
       )
 
     t.deepEqual(
-      cleanStack(parameters.message, 3).replace(
+      cleanStack(parameters.message, 2).replace(
         /(imported from )[^\r\n]+/,
         '$1zzz'
       ),
-      "Error: Cannot find `xxx-missing-yyy` locally but using `defaultProcessor`, original error:\nError [ERR_MODULE_NOT_FOUND]: Cannot find package 'xxx-missing-yyy' imported from zzz\n    at new NodeError (errors.js:1:1)",
+      "Error: Cannot find `xxx-missing-yyy` locally but using `defaultProcessor`, original error:\nError [ERR_MODULE_NOT_FOUND]: Cannot find package 'xxx-missing-yyy' imported from zzz",
       'should work w/ `defaultProcessor`'
     )
   }

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,140 @@ test('`textDocument/didOpen`, `textDocument/didClose` (and diagnostics)', async 
   t.end()
 })
 
+test('uninstalled processor so `window/showMessageRequest`', async (t) => {
+  const stdin = new PassThrough()
+  const promise = execa('node', ['missing-package.js', '--stdio'], {
+    cwd: fileURLToPath(new URL('.', import.meta.url)),
+    input: stdin,
+    timeout
+  })
+
+  stdin.write(
+    toMessage({
+      method: 'initialize',
+      id: 0,
+      /** @type {import('vscode-languageserver').InitializeParams} */
+      params: {
+        processId: null,
+        rootUri: null,
+        capabilities: {},
+        workspaceFolders: null
+      }
+    })
+  )
+
+  await sleep(delay)
+
+  stdin.write(
+    toMessage({
+      method: 'textDocument/didOpen',
+      /** @type {import('vscode-languageserver').DidOpenTextDocumentParams} */
+      params: {
+        textDocument: {
+          uri: new URL('lsp.md', import.meta.url).href,
+          languageId: 'markdown',
+          version: 1,
+          text: '# hi'
+        }
+      }
+    })
+  )
+
+  await sleep(delay)
+
+  assert(promise.stdout)
+  promise.stdout.on('data', () => setImmediate(() => stdin.end()))
+
+  try {
+    await promise
+    t.fail('should reject')
+  } catch (error) {
+    const exception = /** @type {ExecError} */ (error)
+    const messages = fromMessages(exception.stdout)
+    t.equal(messages.length, 2, 'should emit messages')
+    const parameters = messages[1].params
+
+    t.deepEqual(
+      parameters,
+      {
+        type: 3,
+        message:
+          'Cannot turn on language server without `xxx-missing-yyy` locally. Run `npm install xxx-missing-yyy` to enable it',
+        actions: []
+      },
+      'should emit a `window/showMessageRequest` when the processor can’t be found locally'
+    )
+  }
+
+  t.end()
+})
+
+test('uninstalled processor w/ `defaultProcessor`', async (t) => {
+  const stdin = new PassThrough()
+  const promise = execa(
+    'node',
+    ['missing-package-with-default.js', '--stdio'],
+    {
+      cwd: fileURLToPath(new URL('.', import.meta.url)),
+      input: stdin,
+      timeout
+    }
+  )
+
+  stdin.write(
+    toMessage({
+      method: 'initialize',
+      id: 0,
+      /** @type {import('vscode-languageserver').InitializeParams} */
+      params: {
+        processId: null,
+        rootUri: null,
+        capabilities: {},
+        workspaceFolders: null
+      }
+    })
+  )
+
+  await sleep(delay)
+
+  stdin.write(
+    toMessage({
+      method: 'textDocument/didOpen',
+      /** @type {import('vscode-languageserver').DidOpenTextDocumentParams} */
+      params: {
+        textDocument: {
+          uri: new URL('lsp.md', import.meta.url).href,
+          languageId: 'markdown',
+          version: 1,
+          text: '# hi'
+        }
+      }
+    })
+  )
+
+  await sleep(delay)
+
+  assert(promise.stdout)
+  promise.stdout.on('data', () => setImmediate(() => stdin.end()))
+
+  try {
+    await promise
+    t.fail('should reject')
+  } catch (error) {
+    const exception = /** @type {ExecError} */ (error)
+    const messages = fromMessages(exception.stdout)
+    t.equal(messages.length, 2, 'should emit messages')
+    const parameters =
+      /** @type {import('vscode-languageserver').PublishDiagnosticsParams} */ (
+        messages[1].params
+      )
+
+    t.deepEqual(parameters.diagnostics, [], 'should work w/ `defaultProcessor`')
+  }
+
+  t.end()
+})
+
 test('`textDocument/formatting`', async (t) => {
   const stdin = new PassThrough()
 

--- a/test/missing-package-with-default.js
+++ b/test/missing-package-with-default.js
@@ -1,0 +1,7 @@
+import {remark} from 'remark'
+import {createUnifiedLanguageServer} from '../index.js'
+
+createUnifiedLanguageServer({
+  processorName: 'xxx-missing-yyy',
+  defaultProcessor: remark
+})

--- a/test/missing-package.js
+++ b/test/missing-package.js
@@ -1,6 +1,5 @@
 import {createUnifiedLanguageServer} from '../index.js'
 
 createUnifiedLanguageServer({
-  processorName: 'remark',
-  processorSpecifier: 'remark'
+  processorName: 'xxx-missing-yyy'
 })

--- a/test/remark-with-error.js
+++ b/test/remark-with-error.js
@@ -1,5 +1,7 @@
 import {createUnifiedLanguageServer} from '../index.js'
 
 createUnifiedLanguageServer({
-  plugins: ['remark-parse', 'remark-stringify', './one-error.js']
+  processorName: 'remark',
+  processorSpecifier: 'remark',
+  plugins: ['./one-error.js']
 })

--- a/test/remark-with-warnings.js
+++ b/test/remark-with-warnings.js
@@ -1,5 +1,7 @@
 import {createUnifiedLanguageServer} from '../index.js'
 
 createUnifiedLanguageServer({
-  plugins: ['remark-parse', 'remark-stringify', './lots-of-warnings.js']
+  processorName: 'remark',
+  processorSpecifier: 'remark',
+  plugins: ['./lots-of-warnings.js']
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

*   This adds support for loading a local processor (such as `rehype`)
    from the file system (`node_modules/`) in the project
*   By default, it now shows a warningh notification when that
    processor can’t be found locally, instead of throwing an error
*   Optionally, a default processor can be passed when creating the
    language server, which will be used if a local processor can’t be
    found, instead of the previously mentioned warning notification

Related to: remarkjs/remark-language-server#3.

<!--do not edit: pr-->
