### PR TITLE
Fix workspace initialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * @typedef {import('unist').Position} UnistPosition
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('vscode-languageserver').Connection} Connection
- * @typedef {import('vscode-languageserver').InitializeResult} InitializeResult
+ * @typedef {import('vscode-languageserver').InitializeResult<unknown>} InitializeResult
  * @typedef {import('unified-engine').Options} EngineOptions
  * @typedef {Pick<
  *   EngineOptions,

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
  * @typedef {import('unist').Position} UnistPosition
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('vscode-languageserver').Connection} Connection
- * @typedef {import('vscode-languageserver').InitializeResult<unknown>} InitializeResult
  * @typedef {import('unified-engine').Options} EngineOptions
  * @typedef {Pick<
  *   EngineOptions,
@@ -332,25 +331,19 @@ export function configureUnifiedLanguageServer(
         event.capabilities.workspace.workspaceFolders
     )
 
-    /** @type {InitializeResult} */
-    const result = {
+    return {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Full,
         documentFormattingProvider: true,
         codeActionProvider: {
           codeActionKinds: [CodeActionKind.QuickFix],
           resolveProvider: true
-        }
+        },
+        workspace: hasWorkspaceFolderCapability
+          ? {workspaceFolders: {supported: true, changeNotifications: true}}
+          : undefined
       }
     }
-
-    if (hasWorkspaceFolderCapability) {
-      result.capabilities.workspace = {
-        workspaceFolders: {supported: true, changeNotifications: true}
-      }
-    }
-
-    return result
   })
 
   connection.onInitialized(() => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
  * @typedef {import('unist').Position} UnistPosition
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('vscode-languageserver').Connection} Connection
+ * @typedef {import('vscode-languageserver').InitializeResult} InitializeResult
  * @typedef {import('unified-engine').Options} EngineOptions
  * @typedef {Pick<
  *   EngineOptions,
@@ -162,6 +163,7 @@ export function configureUnifiedLanguageServer(
 ) {
   /** @type {Set<string>} */
   const workspaces = new Set()
+  let hasWorkspaceFolderCapability = false
 
   /**
    * Process various LSP text documents using unified and send back the
@@ -325,11 +327,35 @@ export function configureUnifiedLanguageServer(
       workspaces.add(event.rootUri)
     }
 
-    if (
+    hasWorkspaceFolderCapability = Boolean(
       event.capabilities.workspace &&
-      event.capabilities.workspace.workspaceFolders
-    ) {
-      connection.workspace.onDidChangeWorkspaceFolders(function (event) {
+        event.capabilities.workspace.workspaceFolders
+    )
+
+    /** @type {InitializeResult} */
+    const result = {
+      capabilities: {
+        textDocumentSync: TextDocumentSyncKind.Full,
+        documentFormattingProvider: true,
+        codeActionProvider: {
+          codeActionKinds: [CodeActionKind.QuickFix],
+          resolveProvider: true
+        }
+      }
+    }
+
+    if (hasWorkspaceFolderCapability) {
+      result.capabilities.workspace = {
+        workspaceFolders: {supported: true, changeNotifications: true}
+      }
+    }
+
+    return result
+  })
+
+  connection.onInitialized(() => {
+    if (hasWorkspaceFolderCapability) {
+      connection.workspace.onDidChangeWorkspaceFolders((event) => {
         for (const workspace of event.removed) {
           workspaces.delete(workspace.uri)
         }
@@ -340,20 +366,6 @@ export function configureUnifiedLanguageServer(
 
         checkDocuments(...documents.all())
       })
-    }
-
-    return {
-      capabilities: {
-        textDocumentSync: TextDocumentSyncKind.Full,
-        documentFormattingProvider: true,
-        codeActionProvider: {
-          codeActionKinds: [CodeActionKind.QuickFix],
-          resolveProvider: true
-        },
-        workspace: {
-          workspaceFolders: {supported: true, changeNotifications: true}
-        }
-      }
     }
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ import * as exports from 'unified-language-server'
 
 const sleep = promisify(setTimeout)
 
-const delay = process.platform === 'win32' ? 600 : 300
+const delay = process.platform === 'win32' ? 800 : 400
 const timeout = 10_000
 
 test('exports', (t) => {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Without this fix, the error `Unhandled method client/registerCapability` is thrown when this server is started using `vscode-remark`.

The fix was to move `connection.workspace.onDidChangeWorkspaceFolders()` into `connection.onInitialized()`. The initialize result is now also dynamic based on the reported server capabilities. This setup is based on https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#explaining-the-language-server.

<!--do not edit: pr-->
