### PR TITLE
Ensure that the URI of the response matches the request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@
 import path from 'node:path'
 import process from 'node:process'
 import {PassThrough} from 'node:stream'
-import {URL, pathToFileURL, fileURLToPath} from 'node:url'
+import {URL, fileURLToPath} from 'node:url'
 
 import {loadPlugin} from 'load-plugin'
 import {engine} from 'unified-engine'
@@ -142,7 +142,14 @@ function vfileMessageToDiagnostic(message) {
  * @returns {VFile}
  */
 function lspDocumentToVfile(document) {
-  return new VFile({path: new URL(document.uri), value: document.getText()})
+  return new VFile({
+    path: new URL(document.uri),
+    value: document.getText(),
+    data: {
+      // The VFile path resolves symlinks so we store the original uri here
+      uri: document.uri
+    }
+  })
 }
 
 /**
@@ -307,8 +314,9 @@ export function configureUnifiedLanguageServer(
     const files = await processDocuments(textDocuments)
 
     for (const file of files) {
-      // VFile uses a file path, but LSP expects a file URL as a string.
-      const uri = String(pathToFileURL(file.path))
+      // VFile.path for URI restoration is not suitable here because it
+      // resolves symlinks
+      const uri = String(file.data.uri)
       connection.sendDiagnostics({
         uri,
         version: documentVersions.get(uri),


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->

## The problem

The `textDocument/publishDiagnostics` notification modifies the file URI if its path contains a symbolic link.

How to reproduce:

1. Create a workspace where the project root is a symbolic link to another directory containing a markdown file.
2. Ensure that the file URIs sent by the editor are not resolved.
3. The `textDocument/publishDiagnostics` notification contains the resolved file path.

## Expectation

File URIs should be preserved and not resolved.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

## Description of changes

I used the VFile.data property to store the original document URI. I don't like that solution much but it is the best I could find without doing big changes.

I also tried hard to add a test but were not able to accomplish that with reasonable effort.

<!--do not edit: pr-->
