### PR TITLE
Rewrite tests using vscode-jsonrpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "type-coverage": "^2.0.0",
     "typescript": "^4.0.0",
     "unified": "^10.0.0",
+    "vscode-jsonrpc": "^6.0.0",
     "xo": "^0.47.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
-    "execa": "^6.0.0",
     "prettier": "^2.0.0",
     "remark-cli": "^10.0.0",
     "remark-preset-wooorm": "^9.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -812,9 +812,7 @@ function startLanguageServer(t, serverFilePath, cwd) {
   const proc = spawn(
     'node',
     [fileURLToPath(new URL(serverFilePath, import.meta.url)), '--stdio'],
-    {
-      cwd: new URL(cwd, import.meta.url)
-    }
+    {cwd: fileURLToPath(new URL(cwd, import.meta.url))}
   )
   const connection = createMessageConnection(
     new StreamMessageReader(proc.stdout),

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@
 
 import {promises as fs} from 'node:fs'
 import {spawn} from 'node:child_process'
+import path from 'node:path'
 import {URL, fileURLToPath} from 'node:url'
 import test from 'tape'
 
@@ -811,8 +812,14 @@ function cleanStack(stack, max) {
 function startLanguageServer(t, serverFilePath, cwd) {
   const proc = spawn(
     'node',
-    [fileURLToPath(new URL(serverFilePath, import.meta.url)), '--stdio'],
-    {cwd: fileURLToPath(new URL(cwd, import.meta.url))}
+    [
+      path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        serverFilePath
+      ),
+      '--stdio'
+    ],
+    {cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), cwd)}
   )
   const connection = createMessageConnection(
     new StreamMessageReader(proc.stdout),


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This way of testing doesn’t require to use any delays or timeouts.

This also works by sending a response, awaiting a reply, then asserting the reply, instead of sending a number of requests only to assert all responses together later.

Also any logging messages sent from the connection.console are logged to the console in tests.

It’s also less boilerplate per test.

All of these changes together make troubleshooting any tests much nicer to deal with.

This is a draft because I’d like to have some feedback on this testing method and rebase this on #33 before reworking all tests.

<!--do not edit: pr-->
