### PR TITLE
Fix symlinks and more by passing input URIs back

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@
 
 import path from 'node:path'
 import {PassThrough} from 'node:stream'
-import {URL, pathToFileURL, fileURLToPath} from 'node:url'
+import {URL, fileURLToPath} from 'node:url'
 
 import {findUp, pathExists} from 'find-up'
 import {loadPlugin} from 'load-plugin'
@@ -145,7 +145,8 @@ function lspDocumentToVfile(document, cwd) {
   return new VFile({
     cwd,
     path: new URL(document.uri),
-    value: document.getText()
+    value: document.getText(),
+    data: {lspDocumentUri: document.uri}
   })
 }
 
@@ -335,8 +336,9 @@ export function createUnifiedLanguageServer({
     const files = await processDocuments(textDocuments)
 
     for (const file of files) {
-      // VFile uses a file path, but LSP expects a file URL as a string.
-      const uri = String(pathToFileURL(path.resolve(file.cwd, file.path)))
+      // All the vfiles we create have a `lspDocumentUri`.
+      const uri = /** @type {string} */ (file.data.lspDocumentUri)
+
       connection.sendDiagnostics({
         uri,
         version: documentVersions.get(uri),


### PR DESCRIPTION
Related-to GH-32.
Closes GH-38.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

If for some reason symlinks, weird encodings, funky casings, or whatever are passed in URIs as input over the protocol, then we now respond with exactly that same input value, instead of a by Node.js/us resolved and “normalized” value.

<!--do not edit: pr-->