### PR TITLE
Refactor internals

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,6 +173,85 @@ export function createUnifiedLanguageServer({
   let hasWorkspaceFolderCapability = false
 
   /**
+   * @param {string} cwd
+   * @param {VFile[]} files
+   * @param {boolean} alwaysStringify
+   */
+  async function processWorkspace(cwd, files, alwaysStringify) {
+    /** @type {EngineOptions['processor']} */
+    let processor
+
+    try {
+      processor = /** @type {EngineOptions['processor']} */ (
+        await loadPlugin(processorName, {
+          cwd,
+          key: processorSpecifier
+        })
+      )
+    } catch (error) {
+      const exception = /** @type {NodeJS.ErrnoException} */ (error)
+
+      // Pass other funky errors through.
+      /* c8 ignore next 3 */
+      if (exception.code !== 'ERR_MODULE_NOT_FOUND') {
+        throw error
+      }
+
+      if (!defaultProcessor) {
+        connection.window.showInformationMessage(
+          'Cannot turn on language server without `' +
+            processorName +
+            '` locally. Run `npm install ' +
+            processorName +
+            '` to enable it'
+        )
+        return []
+      }
+
+      connection.console.log(
+        'Cannot find `' +
+          processorName +
+          '` locally but using `defaultProcessor`, original error:\n' +
+          exception.stack
+      )
+
+      processor = defaultProcessor
+    }
+
+    return new Promise((resolve, reject) => {
+      engine(
+        {
+          alwaysStringify,
+          cwd,
+          files,
+          ignoreName,
+          packageField,
+          pluginPrefix,
+          plugins,
+          processor,
+          quiet: false,
+          rcName,
+          silentlyIgnore: true,
+          streamError: new PassThrough(),
+          streamOut: new PassThrough()
+        },
+        (error, _, context) => {
+          // An error never occured and can’t be reproduced. This is an internal
+          // error in unified-engine. If a plugin throws, it’s reported as a
+          // vfile message.
+          /* c8 ignore start */
+          if (error) {
+            reject(error)
+          } else {
+            resolve((context && context.files) || [])
+          }
+          /* c8 ignore stop */
+        }
+      )
+    })
+  }
+
+  /**
    * Process various LSP text documents using unified and send back the
    * resulting messages as diagnostics.
    *
@@ -239,80 +318,7 @@ export function createUnifiedLanguageServer({
     const promises = []
 
     for (const [cwd, files] of workspacePathToFiles) {
-      promises.push(
-        (async function () {
-          /** @type {EngineOptions['processor']} */
-          let processor
-
-          try {
-            // @ts-expect-error: assume we load a unified processor.
-            processor = await loadPlugin(processorName, {
-              cwd,
-              key: processorSpecifier
-            })
-          } catch (error) {
-            const exception = /** @type {NodeJS.ErrnoException} */ (error)
-
-            // Pass other funky errors through.
-            /* c8 ignore next 3 */
-            if (exception.code !== 'ERR_MODULE_NOT_FOUND') {
-              throw error
-            }
-
-            if (!defaultProcessor) {
-              connection.window.showInformationMessage(
-                'Cannot turn on language server without `' +
-                  processorName +
-                  '` locally. Run `npm install ' +
-                  processorName +
-                  '` to enable it'
-              )
-              return []
-            }
-
-            connection.console.log(
-              'Cannot find `' +
-                processorName +
-                '` locally but using `defaultProcessor`, original error:\n' +
-                exception.stack
-            )
-
-            processor = defaultProcessor
-          }
-
-          return new Promise((resolve, reject) => {
-            engine(
-              {
-                alwaysStringify,
-                cwd,
-                files,
-                ignoreName,
-                packageField,
-                pluginPrefix,
-                plugins,
-                processor,
-                quiet: false,
-                rcName,
-                silentlyIgnore: true,
-                streamError: new PassThrough(),
-                streamOut: new PassThrough()
-              },
-              (error, _, context) => {
-                // An error never occured and can’t be reproduced. This is an internal
-                // error in unified-engine. If a plugin throws, it’s reported as a
-                // vfile message.
-                /* c8 ignore start */
-                if (error) {
-                  reject(error)
-                } else {
-                  resolve((context && context.files) || [])
-                }
-              }
-            )
-          })
-        })()
-        /* c8 ignore stop */
-      )
+      promises.push(processWorkspace(cwd, files, alwaysStringify))
     }
 
     const listsOfFiles = await Promise.all(promises)

--- a/lib/index.js
+++ b/lib/index.js
@@ -245,11 +245,11 @@ export function createUnifiedLanguageServer({
           } else {
             resolve((context && context.files) || [])
           }
-          /* c8 ignore stop */
         }
       )
     })
   }
+  /* c8 ignore stop */
 
   /**
    * Process various LSP text documents using unified and send back the


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This is just an internal refactor. Upcoming changes will call this function in multiple places, but this way the diffs of those changes will be easier to follow.

One `@ts-expect-error` statement has been changed into a type cast.

<!--do not edit: pr-->
