### PR TITLE
Remove support for Node.js 12, update `unified-engine`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - lts/erbium
+          - lts/fermium
           - lts/gallium

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,7 @@ function vfileMessageToDiagnostic(message) {
   }
 
   if (message.expected) {
+    // type-coverage:ignore-next-line
     diagnostic.data = {
       expected: message.expected
     }
@@ -458,12 +459,13 @@ export function createUnifiedLanguageServer({
     }
 
     for (const diagnostic of event.context.diagnostics) {
-      const {data} = diagnostic
+      // type-coverage:ignore-next-line
+      const data = /** @type {{expected?: unknown[]}} */ (diagnostic.data)
       if (typeof data !== 'object' || !data) {
         continue
       }
 
-      const {expected} = /** @type {{expected?: unknown[]}} */ (data)
+      const {expected} = data
 
       if (!Array.isArray(expected)) {
         continue

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "dependencies": {
     "@types/unist": "^2.0.0",
     "find-up": "^6.0.0",
-    "load-plugin": "^4.0.0",
-    "unified-engine": "^9.0.0",
+    "load-plugin": "^5.0.0",
+    "unified-engine": "^10.0.0",
     "vfile": "^5.0.0",
     "vfile-message": "^3.0.0",
-    "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver": "^8.0.0",
     "vscode-languageserver-textdocument": "^1.0.0"
   },
   "devDependencies": {
@@ -53,7 +53,7 @@
     "typescript": "^4.0.0",
     "unified": "^10.0.0",
     "vscode-languageserver-protocol": "^3.0.0",
-    "xo": "^0.48.0"
+    "xo": "^0.50.0"
   },
   "scripts": {
     "prepack": "npm run build",
@@ -72,7 +72,10 @@
     "trailingComma": "none"
   },
   "xo": {
-    "prettier": true
+    "prettier": true,
+    "rules": {
+      "capitalized-comments": "off"
+    }
   },
   "remarkConfig": {
     "plugins": [

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ various editors.
 ## Install
 
 This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
-In Node.js (version 12.20+, 14.14+, or 16.0+), install with [npm][]:
+In Node.js (version 14.14+, or 16.0+), install with [npm][]:
 
 ```sh
 npm install unified-language-server
@@ -209,11 +209,11 @@ server features:
 
 Projects maintained by the unified collective are compatible with all maintained
 versions of Node.js.
-As of now, that is Node.js 12.20+, 14.14+, and 16.0+.
+As of now, that is Node.js 14.14+, and 16.0+.
 Our projects sometimes work with older versions, but this is not guaranteed.
 
 This project uses [`vscode-languageserver`][vscode-languageserver] 7, which
-implements language server protocol 3.16.0.
+implements language server protocol 3.17.0.
 It should work anywhere where LSP 3.6.0 or later is implemented.
 
 ## Related

--- a/test/index.js
+++ b/test/index.js
@@ -245,7 +245,7 @@ test('uninstalled processor w/ `defaultProcessor`', async (t) => {
 
   t.deepEqual(
     cleanStack(log.message, 2).replace(/(imported from )[^\r\n]+/, '$1zzz'),
-    "Cannot find `xxx-missing-yyy` locally but using `defaultProcessor`, original error:\nError [ERR_MODULE_NOT_FOUND]: Cannot find package 'xxx-missing-yyy' imported from zzz",
+    "Cannot find `xxx-missing-yyy` locally but using `defaultProcessor`, original error:\nError: Cannot find package 'xxx-missing-yyy' imported from zzz",
     'should work w/ `defaultProcessor`'
   )
 })
@@ -679,10 +679,7 @@ test('`workspace/didChangeWorkspaceFolders`', async (t) => {
     workspaceFolders: [{uri: processCwd.href, name: ''}]
   })
 
-  await new Promise((resolve) => {
-    connection.onRequest('client/registerCapability', resolve)
-    connection.sendNotification('initialized', {})
-  })
+  connection.sendNotification('initialized', {})
 
   const otherCwd = new URL('folder/', processCwd)
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Most notably this means:

- YAML configuration files are strictly parsed as YAML 1.2
- Node.js 12 support has been dropped
- The server now implements LSP 3.17 (which should be backwards compatible)

Some internal changes were needed to make CI pass, but none of them affect the end user.

For details see the [LSP changelog](https://github.com/microsoft/vscode-languageserver-node#3170-protocol-800-json-rpc-800-client-and-800-server) and the [unified-engine release](https://github.com/unifiedjs/unified-engine/releases/tag/10.0.0).

<!--do not edit: pr-->
