### PR TITLE
Add `isPreferred` to single suggestions for autofixing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -479,23 +479,25 @@ export function createUnifiedLanguageServer({
           continue
         }
 
-        codeActions.push(
-          CodeAction.create(
-            replacement
-              ? start.line === end.line && start.character === end.character
-                ? 'Insert `' + replacement + '`'
-                : 'Replace `' + actual + '` with `' + replacement + '`'
-              : 'Remove `' + actual + '`',
-            {
-              changes: {
-                [document.uri]: [
-                  TextEdit.replace(diagnostic.range, replacement)
-                ]
-              }
-            },
-            CodeActionKind.QuickFix
-          )
+        const codeAction = CodeAction.create(
+          replacement
+            ? start.line === end.line && start.character === end.character
+              ? 'Insert `' + replacement + '`'
+              : 'Replace `' + actual + '` with `' + replacement + '`'
+            : 'Remove `' + actual + '`',
+          {
+            changes: {
+              [document.uri]: [TextEdit.replace(diagnostic.range, replacement)]
+            }
+          },
+          CodeActionKind.QuickFix
         )
+
+        if (expected.length === 1) {
+          codeAction.isPreferred = true
+        }
+
+        codeActions.push(codeAction)
       }
     }
 

--- a/test/code-actions.js
+++ b/test/code-actions.js
@@ -24,6 +24,12 @@ function warn() {
       end: {line: 1, column: 7}
     }).expected = ['']
 
+    // Insert
+    file.message('', {
+      start: {line: 1, column: 1},
+      end: {line: 1, column: 7}
+    }).expected = ['alternative a', 'alternative b']
+
     // @ts-expect-error We are deliberately testing invalid types here, because
     // the expected field used to be untyped for a long time.
     file.message('', {line: 1, column: 1}).expected = 'insert me'

--- a/test/index.js
+++ b/test/index.js
@@ -453,7 +453,8 @@ test('`textDocument/codeAction` (and diagnostics)', async (t) => {
             ]
           }
         },
-        kind: 'quickfix'
+        kind: 'quickfix',
+        isPreferred: true
       },
       {
         title: 'Replace `actual` with `replacement`',
@@ -470,7 +471,8 @@ test('`textDocument/codeAction` (and diagnostics)', async (t) => {
             ]
           }
         },
-        kind: 'quickfix'
+        kind: 'quickfix',
+        isPreferred: true
       },
       {
         title: 'Remove `actual`',
@@ -483,6 +485,41 @@ test('`textDocument/codeAction` (and diagnostics)', async (t) => {
                   end: {line: 0, character: 6}
                 },
                 newText: ''
+              }
+            ]
+          }
+        },
+        kind: 'quickfix',
+        isPreferred: true
+      },
+      {
+        title: 'Replace `actual` with `alternative a`',
+        edit: {
+          changes: {
+            [uri]: [
+              {
+                range: {
+                  start: {line: 0, character: 0},
+                  end: {line: 0, character: 6}
+                },
+                newText: 'alternative a'
+              }
+            ]
+          }
+        },
+        kind: 'quickfix'
+      },
+      {
+        title: 'Replace `actual` with `alternative b`',
+        edit: {
+          changes: {
+            [uri]: [
+              {
+                range: {
+                  start: {line: 0, character: 0},
+                  end: {line: 0, character: 6}
+                },
+                newText: 'alternative b'
               }
             ]
           }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This allows users to fix the issues using auto fix.

Closes #46

<!--do not edit: pr-->
