### PR TITLE
Refactor to use `fs/promises`

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
  * @typedef {import('vscode-languageserver-protocol').ProtocolConnection} ProtocolConnection
  */
 
-import {promises as fs} from 'node:fs'
+import fs from 'node:fs/promises'
 import {spawn} from 'node:child_process'
 import path from 'node:path'
 import {URL, fileURLToPath} from 'node:url'


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

IMO This looks slightly nicer than using the named `promises` import. This wasn’t supported yet in Node.js 12.

<!--do not edit: pr-->
