### PR TITLE
Fix to ignore document formatting outside workspace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -409,12 +409,12 @@ export function createUnifiedLanguageServer({
       return
     }
 
-    const files = await processDocuments([document], true)
-    if (files.length !== 1) {
+    const [file] = await processDocuments([document], true)
+    if (!file) {
       return
     }
 
-    const result = String(files[0])
+    const result = String(file)
     const text = document.getText()
     if (result === text) {
       return

--- a/lib/index.js
+++ b/lib/index.js
@@ -410,6 +410,7 @@ export function createUnifiedLanguageServer({
     }
 
     const [file] = await processDocuments([document], true)
+
     if (!file) {
       return
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -303,9 +303,6 @@ export function createUnifiedLanguageServer({
           }
         }
 
-        // This presumably should not occur: a file outside a workspace.
-        // So ignore the file.
-        /* c8 ignore next */
         if (!cwd) return
 
         const file = lspDocumentToVfile(textDocument, cwd)
@@ -412,8 +409,12 @@ export function createUnifiedLanguageServer({
       return
     }
 
-    const [file] = await processDocuments([document], true)
-    const result = String(file)
+    const files = await processDocuments([document], true)
+    if (files.length !== 1) {
+      return
+    }
+
+    const result = String(files[0])
     const text = document.getText()
     if (result === text) {
       return

--- a/test/index.js
+++ b/test/index.js
@@ -321,6 +321,30 @@ test('`textDocument/formatting`', async (t) => {
     null,
     'should ignore unsynchronized documents on `textDocument/formatting`'
   )
+
+  connection.sendNotification(DidOpenTextDocumentNotification.type, {
+    textDocument: {
+      uri: new URL('../../outside.md', import.meta.url).href,
+      languageId: 'markdown',
+      version: 1,
+      text: '   #   hi  \n'
+    }
+  })
+
+  const resultOutside = await connection.sendRequest(
+    DocumentFormattingRequest.type,
+    {
+      textDocument: {
+        uri: new URL('../../outside.md', import.meta.url).href
+      },
+      options: {tabSize: 2, insertSpaces: true}
+    }
+  )
+  t.deepEqual(
+    resultOutside,
+    null,
+    'should ignore documents outside of workspace on `textDocument/formatting`'
+  )
 })
 
 test('`workspace/didChangeWatchedFiles`', async (t) => {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Refs https://github.com/remarkjs/vscode-remark/issues/113

<!--do not edit: pr-->
