### PR TITLE
Update dev-dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,8 +32,7 @@
 
 import path from 'node:path'
 import {PassThrough} from 'node:stream'
-import {URL, fileURLToPath} from 'node:url'
-
+import {fileURLToPath} from 'node:url'
 import {findUp, pathExists} from 'find-up'
 import {loadPlugin} from 'load-plugin'
 import {engine} from 'unified-engine'

--- a/package.json
+++ b/package.json
@@ -43,21 +43,21 @@
     "vscode-languageserver-textdocument": "^1.0.0"
   },
   "devDependencies": {
-    "@types/tape": "^4.0.0",
+    "@types/node": "*",
+    "@types/tape": "^5.0.0",
     "c8": "^7.0.0",
     "prettier": "^2.0.0",
     "remark-cli": "^11.0.0",
     "remark-preset-wooorm": "^9.0.0",
     "tape": "^5.0.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
+    "typescript": "^5.0.0",
     "unified": "^10.0.0",
-    "vscode-languageserver-protocol": "^3.0.0",
-    "xo": "^0.51.0"
+    "xo": "^0.54.0"
   },
   "scripts": {
     "prepack": "npm run build",
-    "build": "rimraf \"lib/**/*.d.ts\" \"test/**/*.d.ts\" \"*.d.ts\" && tsc && type-coverage",
+    "build": "tsc --build --clean && tsc --build && type-coverage",
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
     "test-api": "node --unhandled-rejections=strict --conditions development test/index.js",
     "test-coverage": "c8 --check-coverage --100 --reporter lcov npm run test-api",

--- a/test/code-actions.js
+++ b/test/code-actions.js
@@ -6,7 +6,7 @@ createUnifiedLanguageServer({
   plugins: [warn]
 })
 
-/** @type {import('unified').Plugin<Array<void>>} */
+/** @type {import('unified').Plugin<[]>} */
 function warn() {
   return (_, file) => {
     // Insert

--- a/test/folder/remark-with-cwd.js
+++ b/test/folder/remark-with-cwd.js
@@ -6,7 +6,7 @@ createUnifiedLanguageServer({
   plugins: [warn]
 })
 
-/** @type {import('unified').Plugin<Array<void>>} */
+/** @type {import('unified').Plugin<[]>} */
 function warn() {
   return (_, file) => {
     file.message(file.cwd)

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,11 @@
 /**
- * @typedef {import('vscode-languageserver-protocol').ProtocolConnection} ProtocolConnection
+ * @typedef {import('vscode-languageserver').ProtocolConnection} ProtocolConnection
  */
 
-import fs from 'node:fs/promises'
 import {spawn} from 'node:child_process'
+import fs from 'node:fs/promises'
 import path from 'node:path'
-import {URL, fileURLToPath} from 'node:url'
+import {fileURLToPath} from 'node:url'
 import test from 'tape'
 import {
   createProtocolConnection,
@@ -20,7 +20,7 @@ import {
   IPCMessageWriter,
   PublishDiagnosticsNotification,
   ShowMessageRequest
-} from 'vscode-languageserver-protocol/node.js'
+} from 'vscode-languageserver/node.js'
 
 test('`initialize`', async (t) => {
   const connection = startLanguageServer(t, 'remark.js')
@@ -843,7 +843,7 @@ function startLanguageServer(t, serverFilePath, cwd = '.') {
  *
  * @template ReturnType
  * @param {ProtocolConnection} connection
- * @param {import('vscode-languageserver-protocol').NotificationType<ReturnType>} type
+ * @param {import('vscode-languageserver').NotificationType<ReturnType>} type
  * @returns {Promise<ReturnType>}
  */
 async function createOnNotificationPromise(connection, type) {
@@ -860,17 +860,14 @@ async function createOnNotificationPromise(connection, type) {
  *
  * @template Params
  * @param {ProtocolConnection} connection
- * @param {import('vscode-languageserver-protocol').RequestType<Params, any, any>} type
+ * @param {import('vscode-languageserver').RequestType<Params, any, any>} type
  * @returns {Promise<Params>}
  */
 async function createOnRequestPromise(connection, type) {
   return new Promise((resolve) => {
     const disposable = connection.onRequest(type, (result) => {
       disposable.dispose()
-      // The timeout should be 0. However, this causes random test failures.
-      // This will be fixed in vscode-languageserver-protocol 3.17
-      // https://github.com/microsoft/vscode-languageserver-node/pull/776
-      setTimeout(() => resolve(result), 100)
+      resolve(result)
     })
   })
 }

--- a/test/lots-of-warnings.js
+++ b/test/lots-of-warnings.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 
-/** @type {import('unified').Plugin<Array<void>, import('mdast').Root>} */
+/** @type {import('unified').Plugin<[], import('mdast').Root>} */
 export default function lotsOfWarnings() {
   return (tree, file) => {
     // This tiny plugins expects running on a `# heading`.

--- a/test/one-error.js
+++ b/test/one-error.js
@@ -1,4 +1,4 @@
-/** @type {import('unified').Plugin<Array<void>, import('mdast').Root>} */
+/** @type {import('unified').Plugin<[], import('mdast').Root>} */
 export default function oneError() {
   throw new Error('Whoops!')
 }

--- a/test/remark-with-cwd.js
+++ b/test/remark-with-cwd.js
@@ -6,7 +6,7 @@ createUnifiedLanguageServer({
   plugins: [warn]
 })
 
-/** @type {import('unified').Plugin<Array<void>>} */
+/** @type {import('unified').Plugin<[]>} */
 function warn() {
   return (_, file) => {
     file.message(file.cwd)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,13 @@
 {
   "include": ["lib/**/*.js", "test/**/*.js", "*.js"],
   "compilerOptions": {
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "lib": ["es2020"],
+    "module": "node16",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2020",
-    "paths": {
-      "unified-language-server": ["./index.js"]
-    }
+    "target": "es2020"
   }
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

- TypeScript options have been adjusted to TypeScript 5.
- `Array<void>` is not a valid type for `unified.Plugin`. it has been changed to an empty tuple.
- Since `@types/node` now exposes a global `URL`, all `URL` imports were removed.
- The missing dependency `@types/node` was added.
- XO was updated and issues autofixed.
- All imports from `vscode-languageserver-protocol` were changed to `vscode-languageserver`, meaning we don’t need it as an explicit dev dependency either.
- A workaround in a test has been removed, because the issue causing it was resolved upstream.

<!--do not edit: pr-->
