### PR TITLE
Gracefully handle unified-engine errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -230,7 +230,7 @@ export function createUnifiedLanguageServer({
       processor = defaultProcessor
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       engine(
         {
           alwaysStringify,
@@ -248,21 +248,21 @@ export function createUnifiedLanguageServer({
           streamError: new PassThrough(),
           streamOut: new PassThrough()
         },
-        (error, _, context) => {
+        (error) => {
           // An error never occured and can’t be reproduced. This is an internal
           // error in unified-engine. If a plugin throws, it’s reported as a
           // vfile message.
-          /* c8 ignore start */
           if (error) {
-            reject(error)
-          } else {
-            resolve((context && context.files) || [])
+            for (const file of files) {
+              file.message(error).fatal = true
+            }
           }
+
+          resolve(files)
         }
       )
     })
   }
-  /* c8 ignore stop */
 
   /**
    * Process various LSP text documents using unified and send back the

--- a/test/misconfigured.js
+++ b/test/misconfigured.js
@@ -1,0 +1,3 @@
+import {createUnifiedLanguageServer} from 'unified-language-server'
+
+createUnifiedLanguageServer({configurationSection: '', processorName: 'remark'})


### PR DESCRIPTION
Closes #24

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Errors from `unified-engine` are reported as diagnostics on the files the error occurred on. Previously errors were simply unhandled.

<!--do not edit: pr-->
