### PR TITLE
Add `ignorePath` workspace configuration option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,12 @@
  * @typedef UnifiedLanguageServerSettings
  * @property {boolean} [requireConfig=false]
  *   If true, files will only be checked if a configuration file is present.
+ * @property {string | undefined} [ignorePath]
+ *   Filepath to an ignore file to load.
+ *   When relative, it is resolved from the workspace folder.
+ * @property {'cwd' | 'dir' | undefined} [ignorePathResolveFrom]
+ *   Resolve patterns in `ignorePath` from the workspace folder (`'cwd'`)
+ *   or the ignore file’s folder (`'dir'`, the default).
  */
 
 import path from 'node:path'
@@ -158,7 +164,7 @@ export function createUnifiedLanguageServer({
   const workspaces = new Set()
   /** @type {UnifiedLanguageServerSettings} */
   const globalSettings = {requireConfig: false}
-  /** @type {Map<string, Promise<UnifiedLanguageServerSettings>>} */
+  /** @type {Map<string, Promise<Required<Pick<UnifiedLanguageServerSettings, 'requireConfig'>> & Pick<UnifiedLanguageServerSettings, 'ignorePath' | 'ignorePathResolveFrom'>>>} */
   const documentSettings = new Map()
   let hasWorkspaceFolderCapability = false
   let hasConfigurationCapability = false
@@ -178,7 +184,16 @@ export function createUnifiedLanguageServer({
         .getConfiguration({scopeUri, section: configurationSection})
         .then(
           /** @param {Record<string, unknown>} raw */
-          (raw) => ({requireConfig: Boolean(raw.requireConfig)})
+          (raw) => ({
+            requireConfig: Boolean(raw.requireConfig),
+            ignorePath:
+              typeof raw.ignorePath === 'string' ? raw.ignorePath : undefined,
+            ignorePathResolveFrom:
+              raw.ignorePathResolveFrom === 'cwd' ||
+              raw.ignorePathResolveFrom === 'dir'
+                ? raw.ignorePathResolveFrom
+                : undefined
+          })
         )
       documentSettings.set(scopeUri, result)
     }
@@ -187,18 +202,25 @@ export function createUnifiedLanguageServer({
   }
 
   /**
-   * @param {string} cwd
-   * @param {VFile[]} files
-   * @param {boolean} alwaysStringify
-   * @param {boolean} ignoreUnconfigured
+   * @typedef ProcessOptions
+   * @property {string} cwd
+   * @property {VFile[]} files
+   * @property {boolean} alwaysStringify
+   * @property {boolean} ignoreUnconfigured
+   * @property {string | undefined} ignorePath
+   * @property {'cwd' | 'dir' | undefined} ignorePathResolveFrom
+   *
+   * @param {ProcessOptions} options
    * @returns {Promise<VFile[]>}
    */
-  async function processWorkspace(
+  async function processWorkspace({
     cwd,
     files,
     alwaysStringify,
-    ignoreUnconfigured
-  ) {
+    ignoreUnconfigured,
+    ignorePath,
+    ignorePathResolveFrom
+  }) {
     /** @type {EngineOptions['processor']} */
     let processor
 
@@ -239,6 +261,11 @@ export function createUnifiedLanguageServer({
       processor = defaultProcessor
     }
 
+    // Resolve a relative ignore path against the workspace folder.
+    const resolvedIgnorePath = ignorePath
+      ? path.resolve(cwd, ignorePath)
+      : undefined
+
     return new Promise((resolve) => {
       engine(
         {
@@ -246,6 +273,8 @@ export function createUnifiedLanguageServer({
           cwd,
           files,
           ignoreName,
+          ignorePath: resolvedIgnorePath,
+          ignorePathResolveFrom,
           ignoreUnconfigured,
           packageField,
           pluginPrefix,
@@ -288,10 +317,16 @@ export function createUnifiedLanguageServer({
       .map((d) => d.replace(/[/\\]?$/, ''))
       // Sort the longest (closest to the file) first.
       .sort((a, b) => b.length - a.length)
-    /** @type {Map<string, Array<VFile>>} */
-    const workspacePathToFiles = new Map()
-    /** @type {Map<string, Array<VFile>>} */
-    const workspacePathToFilesRequireConfig = new Map()
+    /**
+     * @typedef Group
+     * @property {string} cwd
+     * @property {boolean} ignoreUnconfigured
+     * @property {string | undefined} ignorePath
+     * @property {'cwd' | 'dir' | undefined} ignorePathResolveFrom
+     * @property {VFile[]} files
+     */
+    /** @type {Map<string, Group>} */
+    const groups = new Map()
 
     await Promise.all(
       textDocuments.map(async (textDocument) => {
@@ -334,24 +369,46 @@ export function createUnifiedLanguageServer({
 
         const file = lspDocumentToVfile(textDocument, cwd)
 
-        const filesMap = configuration.requireConfig
-          ? workspacePathToFilesRequireConfig
-          : workspacePathToFiles
-        const files = filesMap.get(cwd) || []
-        files.push(file)
-        filesMap.set(cwd, files)
+        const ignoreUnconfigured = Boolean(configuration.requireConfig)
+        const {ignorePath, ignorePathResolveFrom} = configuration
+        const key =
+          cwd +
+          '\0' +
+          (ignoreUnconfigured ? '1' : '0') +
+          '\0' +
+          (ignorePath || '') +
+          '\0' +
+          (ignorePathResolveFrom || '')
+        let group = groups.get(key)
+        if (!group) {
+          group = {
+            cwd,
+            ignoreUnconfigured,
+            ignorePath,
+            ignorePathResolveFrom,
+            files: []
+          }
+          groups.set(key, group)
+        }
+
+        group.files.push(file)
       })
     )
 
     /** @type {Array<Promise<Array<VFile>>>} */
     const promises = []
 
-    for (const [cwd, files] of workspacePathToFiles) {
-      promises.push(processWorkspace(cwd, files, alwaysStringify, false))
-    }
-
-    for (const [cwd, files] of workspacePathToFilesRequireConfig) {
-      promises.push(processWorkspace(cwd, files, alwaysStringify, true))
+    for (const group of groups.values()) {
+      promises.push(
+        processWorkspace({
+          cwd: group.cwd,
+          files: group.files,
+          alwaysStringify,
+          ignoreUnconfigured: group.ignoreUnconfigured,
+          ignorePath: group.ignorePath,
+          ignorePathResolveFrom: group.ignorePathResolveFrom
+        })
+      )
     }
 
     const listsOfFiles = await Promise.all(promises)
@@ -490,11 +547,20 @@ export function createUnifiedLanguageServer({
       // Reset all cached document settings
       documentSettings.clear()
     } else {
-      globalSettings.requireConfig = Boolean(
+      const settings =
         /** @type {Omit<typeof change, 'settings'> & { settings: Record<string, unknown> }} */ (
           change
-        ).settings.requireConfig
-      )
+        ).settings
+      globalSettings.requireConfig = Boolean(settings.requireConfig)
+      globalSettings.ignorePath =
+        typeof settings.ignorePath === 'string'
+          ? settings.ignorePath
+          : undefined
+      globalSettings.ignorePathResolveFrom =
+        settings.ignorePathResolveFrom === 'cwd' ||
+        settings.ignorePathResolveFrom === 'dir'
+          ? settings.ignorePathResolveFrom
+          : undefined
     }
 
     // Revalidate all open text documents

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,12 @@ server features:
 
 * `requireConfig` (default: `false`)
   — If true, files will only be checked if a configuration file is present.
+* `ignorePath` (`string`, optional)
+  — Filepath to an ignore file to load.
+  When relative, it is resolved from the workspace folder.
+* `ignorePathResolveFrom` (`'cwd' | 'dir'`, default: `'dir'`)
+  — Resolve patterns in `ignorePath` from the workspace folder (`'cwd'`)
+  or the ignore file’s folder (`'dir'`).
 
 ## Compatibility
 

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,9 @@ let connection
 const testremarkrcPath = new URL('.testremarkrc.json', import.meta.url)
 afterEach(() => fs.rm(testremarkrcPath, {force: true}))
 
+const testremarkignorePath = new URL('.testremarkignore', import.meta.url)
+afterEach(() => fs.rm(testremarkignorePath, {force: true}))
+
 afterEach(() => {
   connection?.dispose()
 })
@@ -343,6 +346,135 @@ test('global configuration `requireConfig`', async () => {
     0,
     watchedFileDiagnostics.diagnostics.length,
     'should emit diagnostics if requireConfig is true with config'
+  )
+})
+
+test('workspace configuration `ignorePath`', async () => {
+  const workspace = new URL('./', import.meta.url)
+  await fs.writeFile(testremarkignorePath, 'lsp.md\n')
+  startLanguageServer('remark-with-warnings.js')
+
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: workspace.href,
+    capabilities: {workspace: {configuration: true}},
+    workspaceFolders: null
+  })
+  await new Promise((resolve) => {
+    connection.onRequest(RegistrationRequest.type, resolve)
+    connection.sendNotification(InitializedNotification.type, {})
+  })
+
+  /** @type {Record<string, unknown>} */
+  let configuration = {ignorePathResolveFrom: 'cwd'}
+  connection.onRequest(ConfigurationRequest.type, () => [configuration])
+
+  const uri = new URL('lsp.md', workspace).href
+
+  const openDiagnosticsPromise = createOnNotificationPromise(
+    PublishDiagnosticsNotification.type
+  )
+  connection.sendNotification(DidOpenTextDocumentNotification.type, {
+    textDocument: {uri, languageId: 'markdown', version: 1, text: '# hi'}
+  })
+  const openDiagnostics = await openDiagnosticsPromise
+  assert.notEqual(
+    openDiagnostics.diagnostics.length,
+    0,
+    'should emit diagnostics when `ignorePath` is not set'
+  )
+
+  configuration = {
+    ignorePath: '.testremarkignore',
+    ignorePathResolveFrom: 'invalid'
+  }
+  const changeDiagnosticsPromise = createOnNotificationPromise(
+    PublishDiagnosticsNotification.type
+  )
+  connection.sendNotification(DidChangeConfigurationNotification.type, {
+    settings: {}
+  })
+  const changeDiagnostics = await changeDiagnosticsPromise
+  assert.deepEqual(
+    changeDiagnostics,
+    {uri, version: 1, diagnostics: []},
+    'should emit empty diagnostics when `ignorePath` matches the file'
+  )
+})
+
+test('global configuration `ignorePath`', async () => {
+  const workspace = new URL('./', import.meta.url)
+  await fs.writeFile(testremarkignorePath, 'lsp.md\n')
+  startLanguageServer('remark-with-warnings.js')
+
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: workspace.href,
+    capabilities: {},
+    workspaceFolders: null
+  })
+
+  const uri = new URL('lsp.md', workspace).href
+
+  const openDiagnosticsPromise = createOnNotificationPromise(
+    PublishDiagnosticsNotification.type
+  )
+  connection.sendNotification(DidOpenTextDocumentNotification.type, {
+    textDocument: {uri, languageId: 'markdown', version: 1, text: '# hi'}
+  })
+  const openDiagnostics = await openDiagnosticsPromise
+  assert.notEqual(
+    openDiagnostics.diagnostics.length,
+    0,
+    'should emit diagnostics when `ignorePath` is not set'
+  )
+
+  const changeDiagnosticsPromise = createOnNotificationPromise(
+    PublishDiagnosticsNotification.type
+  )
+  connection.sendNotification(DidChangeConfigurationNotification.type, {
+    settings: {
+      ignorePath: '.testremarkignore',
+      ignorePathResolveFrom: 'cwd'
+    }
+  })
+  const changeDiagnostics = await changeDiagnosticsPromise
+  assert.deepEqual(
+    changeDiagnostics,
+    {uri, version: 1, diagnostics: []},
+    'should emit empty diagnostics when `ignorePath` matches the file'
+  )
+})
+
+test('global configuration ignores invalid `ignorePath` types', async () => {
+  startLanguageServer('remark-with-warnings.js')
+  await connection.sendRequest(InitializeRequest.type, {
+    processId: null,
+    rootUri: null,
+    capabilities: {},
+    workspaceFolders: null
+  })
+  const uri = new URL('lsp.md', import.meta.url).href
+
+  const openDiagnosticsPromise = createOnNotificationPromise(
+    PublishDiagnosticsNotification.type
+  )
+  connection.sendNotification(DidOpenTextDocumentNotification.type, {
+    textDocument: {uri, languageId: 'markdown', version: 1, text: '# hi'}
+  })
+  await openDiagnosticsPromise
+
+  const changeDiagnosticsPromise = createOnNotificationPromise(
+    PublishDiagnosticsNotification.type
+  )
+  connection.sendNotification(DidChangeConfigurationNotification.type, {
+    settings: {ignorePath: 42, ignorePathResolveFrom: 'invalid'}
+  })
+  const changeDiagnostics = await changeDiagnosticsPromise
+  assert.notEqual(
+    changeDiagnostics.diagnostics.length,
+    0,
+    'should ignore invalid `ignorePath` and process normally'
   )
 })
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aunifiedjs&type=issues and https://github.com/orgs/unifiedjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Resolves part of remarkjs/vscode-remark#142. Adds `ignorePath` and `ignorePathResolveFrom` workspace configuration options that pass through to `unified-engine`, mirroring its CLI flag of the same name. Existing behavior is unchanged when the options are not set.

<!--do not edit: pr-->
